### PR TITLE
feat: traitの重複に関する検証

### DIFF
--- a/spec/factories/city.rb
+++ b/spec/factories/city.rb
@@ -1,0 +1,18 @@
+require './src/models/city'
+
+FactoryBot.define do
+  factory :city, class: City do
+
+    trait :sapporo do
+      name { '札幌市' }
+    end
+
+    trait :gifu do
+      name { '岐阜市' }
+    end
+  end
+
+  trait :duplication_test do
+    name { '重複テスト' }
+  end
+end

--- a/spec/factories/prefecture.rb
+++ b/spec/factories/prefecture.rb
@@ -1,0 +1,25 @@
+require './src/models/prefecture'
+
+FactoryBot.define do
+  factory :prefecture, class: Prefecture do
+
+    trait :hokkaido do
+      code { '01' }
+      name { '北海道' }
+    end
+
+    trait :gifu do
+      code { '21' }
+      name { 'old岐阜県' }
+    end
+
+    trait :gifu do
+      code { '21' }
+      name { '岐阜県' }
+    end
+  end
+
+  trait :duplication_test do
+    name { '重複テスト' }
+  end
+end

--- a/spec/verification/factory_bot_trait_spec.rb
+++ b/spec/verification/factory_bot_trait_spec.rb
@@ -1,0 +1,54 @@
+require './spec/factories/prefecture'
+
+RSpec.describe do
+  describe 'trait' do
+    describe '定義の重複' do
+      context 'FactoryBot.define直下にて定義が重複している場合' do
+        it 'FactoryBot::DuplicateDefinitionErrorが発生すること' do
+          expect do
+            require './spec/factories/city'
+          end.to raise_error(FactoryBot::DuplicateDefinitionError)
+          # FactoryBot::DuplicateDefinitionError:
+          #  Trait already registered: duplication_test
+        end
+
+        # おまけ: factoryブロックの外にあるtraitを指定した場合にどうなるのか
+        context '第一引数に指定した場合' do
+          it 'KeyErrorが発生すること' do
+            expect do
+              FactoryBot.build(:duplication_test)
+            end.to raise_error(KeyError)
+            # KeyError:
+            #   Factory not registered: "duplication_test"
+          end
+        end
+
+        context '第二引数に指定した場合' do
+          let(:prefecture) { FactoryBot.build(:prefecture, :duplication_test) }
+
+          it '第一引数に指定したインスタンスが生成されていること' do
+            expect(prefecture.instance_of?(Prefecture)).to be_truthy
+            expect(prefecture.name).to eq '重複テスト'
+          end
+        end
+      end
+
+      context 'factoryブロック内にて重複している場合' do
+        let(:prefecture) { FactoryBot.build(:prefecture, :gifu) }
+
+        it '先に定義されたものが優先されていること' do
+          expect(prefecture.name).to eq 'old岐阜県'
+          # trait :gifu do
+          #   code { '21' }
+          #   name { 'old岐阜県' }
+          # end
+          #
+          # trait :gifu do
+          #   code { '21' }
+          #   name { '岐阜県' }
+          # end
+        end
+      end
+    end
+  end
+end

--- a/src/models/city.rb
+++ b/src/models/city.rb
@@ -1,0 +1,3 @@
+class City
+  attr_accessor :name
+end

--- a/src/models/prefecture.rb
+++ b/src/models/prefecture.rb
@@ -1,0 +1,3 @@
+class Prefecture
+  attr_accessor :code, :name, :city
+end


### PR DESCRIPTION
## 概要
- taritが重複していた場合、どのような動きをするのかを検証する

## 検証内容
### `FactoryBot.define`直下にて重複していた場合
#### 仮説
- キーの重複にて例外が発生する

#### 結果
- 以下の例外が発生した
   ```ruby
   FactoryBot::DuplicateDefinitionError:
     Trait already registered: duplication_test
   ```

### `factory`ブロック直下にて重複していた場合
#### 仮説
- キーの重複にて例外が発生する

#### 結果
<details>

- 先に定義されていたものが優先される

</details>